### PR TITLE
Add Autodarts scraping Chrome extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# darts-scraper
+# Autodarts Scraper Chrome Extension
+
+This repository contains a Chrome extension that lets you define variables on [Autodarts](https://autodarts.io) pages via CSS selectors. Values are scraped and displayed in a live updating dashboard window.
+
+## Usage
+
+1. Load the extension in Chrome by visiting `chrome://extensions`, enabling *Developer mode*, and clicking **Load unpacked**.
+2. Choose this folder.
+3. Navigate to an Autodarts page and open the extension popup.
+4. Enter a variable name and CSS selector, then click **Variable hinzufügen**.
+5. Click **Dashboard öffnen** to view a new window that shows the values in real time.
+
+## Development
+
+Variables and values are stored in `chrome.storage`. A content script watches the selected elements using `MutationObserver` and updates the dashboard whenever changes occur.

--- a/content.js
+++ b/content.js
@@ -1,0 +1,40 @@
+const observers = {};
+
+function sendValue(name, element) {
+  const value = element.textContent.trim();
+  chrome.storage.sync.get('values', data => {
+    const values = data.values || {};
+    values[name] = value;
+    chrome.storage.sync.set({values});
+    chrome.runtime.sendMessage({type: 'update', name, value});
+  });
+}
+
+function watchVariable(v) {
+  const element = document.querySelector(v.selector);
+  if (!element) return;
+  sendValue(v.name, element);
+  const observer = new MutationObserver(() => sendValue(v.name, element));
+  observer.observe(element, {childList: true, subtree: true, characterData: true});
+  observers[v.name] = observer;
+}
+
+function setupWatchers(vars) {
+  Object.values(observers).forEach(o => o.disconnect());
+  for (const k in observers) delete observers[k];
+  vars.forEach(watchVariable);
+}
+
+function init() {
+  chrome.storage.sync.get('variables', data => {
+    setupWatchers(data.variables || []);
+  });
+}
+
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === 'sync' && changes.variables) {
+    setupWatchers(changes.variables.newValue || []);
+  }
+});
+
+init();

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Autodarts Dashboard</title>
+  <style>
+    body { font-family: sans-serif; padding: 10px; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { border: 1px solid #ccc; padding: 4px; text-align: left; }
+  </style>
+</head>
+<body>
+  <h1>Autodarts Werte</h1>
+  <table id="values">
+    <thead><tr><th>Name</th><th>Wert</th></tr></thead>
+    <tbody></tbody>
+  </table>
+  <script src="dashboard.js"></script>
+</body>
+</html>

--- a/dashboard.js
+++ b/dashboard.js
@@ -1,0 +1,22 @@
+function render(values) {
+  const tbody = document.querySelector('#values tbody');
+  tbody.innerHTML = '';
+  Object.entries(values).forEach(([name, value]) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${name}</td><td>${value}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+async function init() {
+  const {values = {}} = await chrome.storage.sync.get('values');
+  render(values);
+}
+
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.type === 'update') {
+    chrome.storage.sync.get('values', data => render(data.values || {}));
+  }
+});
+
+init();

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,18 @@
+{
+  "manifest_version": 3,
+  "name": "Autodarts Scraper",
+  "version": "1.0",
+  "description": "Scrapes values from Autodarts and displays them in a live dashboard.",
+  "permissions": ["storage", "scripting", "activeTab"],
+  "host_permissions": ["https://autodarts.io/*"],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Autodarts Scraper"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://autodarts.io/*"],
+      "js": ["content.js"]
+    }
+  ]
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Autodarts Scraper</title>
+  <style>
+    body { font-family: sans-serif; width: 300px; padding: 10px; }
+    label { display: block; margin-top: 10px; }
+    input[type=text] { width: 100%; }
+    button { margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <h1>Scraper</h1>
+  <label>Variable Name <input type="text" id="var-name"></label>
+  <label>CSS Selector <input type="text" id="var-selector"></label>
+  <button id="add">Variable hinzufügen</button>
+  <button id="open">Dashboard öffnen</button>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,19 @@
+document.getElementById('add').addEventListener('click', async () => {
+  const name = document.getElementById('var-name').value.trim();
+  const selector = document.getElementById('var-selector').value.trim();
+  if (!name || !selector) return;
+  const {variables = []} = await chrome.storage.sync.get('variables');
+  variables.push({name, selector});
+  await chrome.storage.sync.set({variables});
+  document.getElementById('var-name').value = '';
+  document.getElementById('var-selector').value = '';
+});
+
+document.getElementById('open').addEventListener('click', () => {
+  chrome.windows.create({
+    url: chrome.runtime.getURL('dashboard.html'),
+    type: 'popup',
+    width: 400,
+    height: 600
+  });
+});


### PR DESCRIPTION
## Summary
- add manifest and content scripts for Autodarts scraping Chrome extension
- provide popup to define variables and open live dashboard window
- display scraped values updating in real time

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_b_68aef7acc0c08332abe4d015f60db6f4