### PR TITLE
Remove WebSocket export and improve popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Autodarts Live Scraper (Chrome Extension)
 
-Scraped **Live-Daten** aus `play.autodarts.io` – im Dashboard sichtbar, via **WebSocket** und optional per **HTTP POST** exportiert. Ideal für Overlays, Analysen & Automationen.  
+Scraped **Live-Daten** aus `play.autodarts.io` – im Dashboard sichtbar und optional per **HTTP POST** exportiert. Ideal für Overlays, Analysen & Automationen.
 **Version:** 1.0.4 · **Manifest:** MV3
 
 ---
@@ -11,7 +11,7 @@ Scraped **Live-Daten** aus `play.autodarts.io` – im Dashboard sichtbar, via **
 - Variablen per Klick auswählen (**Picker**)
 - Settings speichern + **XML Import/Export** (`settings.xml` mitgeliefert)
 - Live-Updates **ohne Reload** (MutationObserver)
-- **WebSocket**-Export + optional **HTTP POST** (Webhook)
+- Optional **HTTP POST** (Webhook)
 - Zahlen-Fallback: fehlende `legs/sets` → **0**
 
 ---
@@ -29,7 +29,6 @@ Scraped **Live-Daten** aus `play.autodarts.io` – im Dashboard sichtbar, via **
 1. Dashboard öffnen → **Settings** → **Werkseinstellungen laden** (importiert `settings.xml`).  
 2. Variablen anpassen: **„+ Variable per Klick auswählen“**.  
 3. Exporte setzen:
-   - **WebSocket URL** (z. B. `ws://localhost:8765`)
    - **HTTP POST** aktivieren + URL (z. B. `http://localhost:3000/hook`)
 4. Tab **Output** prüfen – JSON ändert sich live.
 

--- a/content/autoscrape.js
+++ b/content/autoscrape.js
@@ -2,8 +2,6 @@ var ORIGIN_KEY = location.host;
 function normalizeConfig(r) {
   var c = r || {};
   if (!Array.isArray(c.variables)) c.variables = [];
-  if (typeof c.wsUrl !== "string")
-    c.wsUrl = c.export && c.export.wsUrl ? c.export.wsUrl : "";
   if (!c.webhook)
     c.webhook =
       c.export && c.export.webhook

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
-  "name": "AutodartsWebSocket",
+  "name": "AutodartsScraper",
   "version": "1.0.4",
-  "description": "Scrape live data from play.autodarts.io with clickable selection, live updates, WebSocket export, and HTTP POST webhook.",
+  "description": "Scrape live data from play.autodarts.io with clickable selection, live updates, and optional HTTP POST webhook.",
   "permissions": ["storage", "scripting", "activeTab", "contextMenus", "tabs"],
   "host_permissions": ["https://play.autodarts.io/*"],
   "background": {

--- a/options.html
+++ b/options.html
@@ -1,1 +1,95 @@
-<!doctype html><html lang="de"><head><meta charset="utf-8"><title>Autodarts Scraper – Dashboard</title><meta name="viewport" content="width=device-width, initial-scale=1"><link rel="stylesheet" href="options.css"></head><body><header><h1>Autodarts Scraper</h1><nav><button id="tab-settings" class="tab active">Settings</button><button id="tab-output" class="tab">Output</button></nav></header><main><section id="view-settings" class="view active"><div class="card"><h2>Seite</h2><div class="row"><label>Origin (Host):</label><input id="origin" placeholder="play.autodarts.io" /><button id="loadOrigin">Laden</button></div></div><div class="card"><h2>Variablen</h2><div class="row"><button id="addVar">+ Variable per Klick auswählen</button><button id="manualVar">+ Variable manuell</button></div><table id="vars"><thead><tr><th>Name</th><th>Selector</th><th>Modus</th><th>Attribut/Regex</th><th></th></tr></thead><tbody></tbody></table><div class="row right"><button class="secondary" id="testVars">Jetzt testen</button><button id="save">Speichern</button></div></div><div class="card"><h2>WebSocket</h2><div class="row"><label>WebSocket URL:</label><input id="wsUrl" placeholder="ws://localhost:8765" /></div></div><div class="card"><h2>HTTP POST</h2><div class="row"><label class="inline"><input type="checkbox" id="whEnabled"> aktivieren</label><input id="whUrl" placeholder="https://example.com/hook" /></div><p class="hint">Sende bei Änderung JSON an diese URL (Content-Type: application/json).</p></div><div class="card"><h2>Tools</h2><div class="row"><button class="secondary" id="downloadXml">Settings als XML herunterladen</button><input type="file" id="importXml" accept=".xml,application/xml" style="display:none;" /><button id="importBtn">Settings aus XML importieren</button><button id="importDefaultsBtn">Werkseinstellungen laden</button></div></div></section><section id="view-output" class="view"><div class="card"><h2>Live Output</h2><pre id="liveJson">{}</pre><div class="row"><button id="copyJson">JSON kopieren</button><button id="refresh">Aktualisieren</button></div></div></section></main><div id="addVarModal" class="modal hidden"><div class="modal-card"><h3>Variable hinzufügen</h3><div class="row"><label>Selector</label><input id="m-selector" readonly /></div><div class="row"><label>Beispiel</label><input id="m-sample" readonly /></div><div class="row"><label>Name</label><input id="m-name" placeholder="z. B. player1_score" /></div><div class="row"><label>Modus</label><select id="m-mode"><option value="text">text</option><option value="number">number</option><option value="attr">attr</option></select></div><div class="row" id="m-extra-row"><label id="m-extra-label">Regex / Attribut</label><input id="m-extra" placeholder="bei number: Regex, bei attr: Attribut-Name" /></div><div class="row right"><button class="secondary" id="m-cancel">Abbrechen</button><button id="m-add">Hinzufügen</button></div></div></div><footer><small>v1.0.4</small></footer><script src="options.js"></script></body></html>
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8" />
+    <title>Autodarts Scraper – Dashboard</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="options.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Autodarts Scraper</h1>
+      <nav>
+        <button id="tab-settings" class="tab active">Settings</button>
+        <button id="tab-output" class="tab">Output</button>
+      </nav>
+    </header>
+    <main>
+      <section id="view-settings" class="view active">
+        <div class="card">
+          <h2>Variablen</h2>
+          <div class="row">
+            <button id="addVar">+ Variable per Klick auswählen</button>
+            <button id="manualVar">+ Variable manuell</button>
+          </div>
+          <table id="vars">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Selector</th>
+                <th>Modus</th>
+                <th>Attribut/Regex</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+          <div class="row right">
+            <button class="secondary" id="testVars">Jetzt testen</button>
+            <button id="save">Speichern</button>
+          </div>
+        </div>
+        <div class="card">
+          <h2>HTTP POST</h2>
+          <div class="row">
+            <label class="inline"
+              ><input type="checkbox" id="whEnabled" /> aktivieren</label
+            ><input id="whUrl" placeholder="https://example.com/hook" />
+          </div>
+          <p class="hint">
+            Sende bei Änderung JSON an diese URL (Content-Type: application/json).
+          </p>
+        </div>
+        <div class="card">
+          <h2>Tools</h2>
+          <div class="row">
+            <button class="secondary" id="downloadXml">
+              Settings als XML herunterladen
+            </button>
+            <input
+              type="file"
+              id="importXml"
+              accept=".xml,application/xml"
+              style="display:none;"
+            />
+            <button id="importBtn">Settings aus XML importieren</button>
+            <button id="importDefaultsBtn">Werkseinstellungen laden</button>
+          </div>
+        </div>
+      </section>
+      <section id="view-output" class="view">
+        <div class="card">
+          <h2>Live Output</h2>
+          <pre id="liveJson">{}</pre>
+          <div class="row">
+            <button id="copyJson">JSON kopieren</button>
+            <button id="refresh">Aktualisieren</button>
+          </div>
+        </div>
+      </section>
+    </main>
+    <div id="addVarModal" class="modal hidden">
+      <div class="modal-card">
+        <h3>Variable hinzufügen</h3>
+        <div class="row"><label>Selector</label><input id="m-selector" readonly /></div>
+        <div class="row"><label>Beispiel</label><input id="m-sample" readonly /></div>
+        <div class="row"><label>Name</label><input id="m-name" placeholder="z. B. player1_score" /></div>
+        <div class="row"><label>Modus</label><select id="m-mode"><option value="text">text</option><option value="number">number</option><option value="attr">attr</option></select></div>
+        <div class="row" id="m-extra-row"><label id="m-extra-label">Regex / Attribut</label><input id="m-extra" placeholder="bei number: Regex, bei attr: Attribut-Name" /></div>
+        <div class="row right"><button class="secondary" id="m-cancel">Abbrechen</button><button id="m-add">Hinzufügen</button></div>
+      </div>
+    </div>
+    <footer><small>v1.0.4</small></footer>
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/popup.html
+++ b/popup.html
@@ -1,1 +1,22 @@
-<!doctype html><html><body>Autodarts</body></html>
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body {
+        min-width: 200px;
+        padding: 10px;
+      }
+      button {
+        display: block;
+        width: 100%;
+        margin: 5px 0;
+      }
+    </style>
+  </head>
+  <body>
+    <button id="addVar">+ Variable per Klick auswählen</button>
+    <button id="openOptions">Optionen öffnen</button>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,37 @@
+const ORIGIN = "play.autodarts.io";
+
+function startPicker() {
+  chrome.tabs
+    .query({ active: true, currentWindow: true })
+    .then(function (tabs) {
+      var tab = tabs && tabs[0];
+      if (!tab) return;
+      var isAd = false;
+      try {
+        isAd = new URL(tab.url || "").host === ORIGIN;
+      } catch (e) {}
+      if (!isAd) {
+        return chrome.tabs.create({ url: "https://" + ORIGIN }).then(function (created) {
+          var tabId = created.id;
+          var listener = function (id, info) {
+            if (id === tabId && info && info.status === "complete") {
+              chrome.runtime.sendMessage({ type: "EXECUTE_PICKER", tabId: tabId }, function () {});
+              chrome.tabs.onUpdated.removeListener(listener);
+            }
+          };
+          chrome.tabs.onUpdated.addListener(listener);
+        });
+      }
+      return chrome.runtime.sendMessage({ type: "EXECUTE_PICKER", tabId: tab.id }, function () {});
+    });
+}
+
+document.getElementById("openOptions").addEventListener("click", function () {
+  if (chrome.runtime.openOptionsPage) chrome.runtime.openOptionsPage();
+});
+
+document.getElementById("addVar").addEventListener("click", function () {
+  if (chrome.runtime.openOptionsPage) chrome.runtime.openOptionsPage();
+  setTimeout(startPicker, 300);
+});
+

--- a/settings.xml
+++ b/settings.xml
@@ -1,1 +1,54 @@
-<autodartsConfig origin="play.autodarts.io"> <wsUrl/> <variables> <variable> <name>player1_name</name> <selector>#ad-ext-player-display > div:nth-of-type(1) .ad-ext-player-name p</selector> <mode>text</mode> </variable> <variable> <name>player2_name</name> <selector>#ad-ext-player-display > div:nth-of-type(2) .ad-ext-player-name p</selector> <mode>text</mode> </variable> <variable> <name>player_active</name> <selector>#ad-ext-player-display .ad-ext-player-active .ad-ext-player-name p</selector> <mode>text</mode> </variable> <variable> <name>player1_score</name> <selector>#ad-ext-player-display > div:nth-of-type(1) .ad-ext-player-score</selector> <mode>number</mode> </variable> <variable> <name>player2_score</name> <selector>#ad-ext-player-display > div:nth-of-type(2) .ad-ext-player-score</selector> <mode>number</mode> </variable> <variable> <name>player1_legs</name> <selector>#ad-ext-player-display > div:nth-of-type(1) .css-1k3nd6z span:nth-of-type(1) p</selector> <mode>number</mode> </variable> <variable> <name>player1_sets</name> <selector>#ad-ext-player-display > div:nth-of-type(1) .css-1k3nd6z span:nth-of-type(2) p</selector> <mode>number</mode> </variable> <variable> <name>player2_legs</name> <selector>#ad-ext-player-display > div:nth-of-type(2) .css-1k3nd6z span:nth-of-type(1) p</selector> <mode>number</mode> </variable> <variable> <name>player2_sets</name> <selector>#ad-ext-player-display > div:nth-of-type(2) .css-1k3nd6z span:nth-of-type(2) p</selector> <mode>number</mode> </variable> <variable> <name>gamemode</name> <selector>#ad-ext-game-variant</selector> <mode>text</mode> </variable> </variables> </autodartsConfig>
+<autodartsConfig origin="play.autodarts.io">
+  <variables>
+    <variable>
+      <name>player1_name</name>
+      <selector>#ad-ext-player-display > div:nth-of-type(1) .ad-ext-player-name p</selector>
+      <mode>text</mode>
+    </variable>
+    <variable>
+      <name>player2_name</name>
+      <selector>#ad-ext-player-display > div:nth-of-type(2) .ad-ext-player-name p</selector>
+      <mode>text</mode>
+    </variable>
+    <variable>
+      <name>player_active</name>
+      <selector>#ad-ext-player-display .ad-ext-player-active .ad-ext-player-name p</selector>
+      <mode>text</mode>
+    </variable>
+    <variable>
+      <name>player1_score</name>
+      <selector>#ad-ext-player-display > div:nth-of-type(1) .ad-ext-player-score</selector>
+      <mode>number</mode>
+    </variable>
+    <variable>
+      <name>player2_score</name>
+      <selector>#ad-ext-player-display > div:nth-of-type(2) .ad-ext-player-score</selector>
+      <mode>number</mode>
+    </variable>
+    <variable>
+      <name>player1_legs</name>
+      <selector>#ad-ext-player-display > div:nth-of-type(1) .css-1k3nd6z span:nth-of-type(1) p</selector>
+      <mode>number</mode>
+    </variable>
+    <variable>
+      <name>player1_sets</name>
+      <selector>#ad-ext-player-display > div:nth-of-type(1) .css-1k3nd6z span:nth-of-type(2) p</selector>
+      <mode>number</mode>
+    </variable>
+    <variable>
+      <name>player2_legs</name>
+      <selector>#ad-ext-player-display > div:nth-of-type(2) .css-1k3nd6z span:nth-of-type(1) p</selector>
+      <mode>number</mode>
+    </variable>
+    <variable>
+      <name>player2_sets</name>
+      <selector>#ad-ext-player-display > div:nth-of-type(2) .css-1k3nd6z span:nth-of-type(2) p</selector>
+      <mode>number</mode>
+    </variable>
+    <variable>
+      <name>gamemode</name>
+      <selector>#ad-ext-game-variant</selector>
+      <mode>text</mode>
+    </variable>
+  </variables>
+</autodartsConfig>


### PR DESCRIPTION
## Summary
- drop WebSocket configuration and related code, leaving only optional HTTP POST export
- simplify options to fixed play.autodarts.io origin and expose webhook settings
- add popup actions to open options and launch variable picker

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_b_68b15b49b6a88332978deb5500a77113